### PR TITLE
Node mapping optional, default sdir to lazyDir and 'exec' is now 'run' in tasks

### DIFF
--- a/vars/lazyConfig.groovy
+++ b/vars/lazyConfig.groovy
@@ -30,7 +30,7 @@ def mapFromText(String text) {
 	logger.debug('mapFromText', 'Convert list of key/pair from String to Map')
 	logger.trace('mapFromText', "Parse from String = " + text.replaceAll("\\\n", "\\\\\\n"))
 	Map map = [:]
-	text.findAll(/([^=\n]+)=([^\n]+)/) { group ->
+	text.findAll(/([^=\n\s,]+)=([^\n\s,]+)/) { group ->
 		// REM: In Groovy console, the Closure parameters are 'full, key, value ->'
 		def key = group[1]
 		def value = group[2]

--- a/vars/lazyConfig.groovy
+++ b/vars/lazyConfig.groovy
@@ -50,12 +50,12 @@ def call(Map args = [:]) {
 		logger.debug('init', 'Preparing config from env if available or hardcoded defaults if needed, squashed with args if set')
 		args = [
 			name:		env.JOB_NAME,
-			sdir:		env.LAZY_SDIR ? env.LAZY_SDIR : 'lazyDir',
+			sdir:		env.LAZY_SDIR ?: 'lazyDir',
 			stages:		env.LAZY_STAGES ? env.LAZY_STAGES.split("/n") : [],
 			flags:		env.LAZY_FLAGS ? env.LAZY_FLAGS.split("/n") : [],
 			labels:		env.LAZY_LABELS ? mapFromText(env.LAZY_LABELS) : [ default: 'master' ],
 			dists:		env.LAZY_DISTS ? env.LAZY_DISTS.split("/n") : [],
-			verbosity:	env.LAZY_VERBOSITY ? env.LAZY_VERBOSITY : 'INFO',
+			verbosity:	env.LAZY_VERBOSITY ?: 'INFO',
 			] + args
 
 		logger.debug('init', 'Generate and retrieve user altered config')

--- a/vars/lazyConfig.groovy
+++ b/vars/lazyConfig.groovy
@@ -50,7 +50,7 @@ def call(Map args = [:]) {
 		logger.debug('init', 'Preparing config from env if available or hardcoded defaults if needed, squashed with args if set')
 		args = [
 			name:		env.JOB_NAME,
-			sdir:		env.LAZY_SDIR ? env.LAZY_SDIR : 'lazy-pipeline',
+			sdir:		env.LAZY_SDIR ? env.LAZY_SDIR : 'lazyDir',
 			stages:		env.LAZY_STAGES ? env.LAZY_STAGES.split("/n") : [],
 			flags:		env.LAZY_FLAGS ? env.LAZY_FLAGS.split("/n") : [],
 			labels:		env.LAZY_LABELS ? mapFromText(env.LAZY_LABELS) : [ default: 'master' ],

--- a/vars/lazyDocker.groovy
+++ b/vars/lazyDocker.groovy
@@ -78,11 +78,8 @@ def call (stage, task, dist, args = '') {
 
 	logger.info('Started')
 
-	// Execute pre closure first
-	if (task.preout) task.preout.call()
-
 	// Prepare steps without executing
-	def steps = lazyStep(stage, task.exec, dist)
+	def steps = lazyStep(stage, task, dist)
 	
 	// Build the relevant Docker image
 	def imgDocker = buildImage(stage, dist)
@@ -96,9 +93,6 @@ def call (stage, task, dist, args = '') {
 			}
 		}
 	}
-
-	// Execute post closure at the end
-	if (task.postout) task.postout.call()
 
 	logger.info('Finished')
 }

--- a/vars/lazyDocker.groovy
+++ b/vars/lazyDocker.groovy
@@ -64,13 +64,11 @@ def buildImage(stage, dist, args = '', filename = 'Dockerfile') {
 	def uid = sh(returnStdout: true, script: 'id -u').trim()
 	def gid = sh(returnStdout: true, script: 'id -g').trim()
 	
-	ansiColor('xterm') {
-		withEnv(["UID=${uid}", "GID=${gid}"]) {
-			return docker.build(
-				"${config.name}-${stage}-${dist}:${config.branch}",
-				"--build-arg dir=${stage} --build-arg uid=${env.UID} --build-arg gid=${env.GID} -f ${config.sdir}/${dstDockerfile} ${config.sdir}"
-			)
-		}
+	withEnv(["UID=${uid}", "GID=${gid}"]) {
+		return docker.build(
+			"${config.name}-${stage}-${dist}:${config.branch}",
+			"--build-arg dir=${stage} --build-arg uid=${env.UID} --build-arg gid=${env.GID} -f ${config.sdir}/${dstDockerfile} ${config.sdir}"
+		)
 	}
 }
 
@@ -91,12 +89,10 @@ def call (stage, task, dist, args = '') {
 
 	// Run each shell scripts as task inside the Docker
 	imgDocker.inside(args) {
-		ansiColor('xterm') {
-			withEnv(["DIST=${dist}"]) {
-				// Execut each step
-				steps.each { step ->
-					step()
-				}
+		withEnv(["DIST=${dist}"]) {
+			// Execut each step
+			steps.each { step ->
+				step()
 			}
 		}
 	}

--- a/vars/lazyNode.groovy
+++ b/vars/lazyNode.groovy
@@ -48,7 +48,7 @@ def call(stage, index, task, target, dist = null) {
 						if (task.pre) task.pre.call()
 
 						if (dist) {
-							lazyDocker(stage, task.run, dist, params.dockerArgs)
+							lazyDocker(stage, task.run, dist, task.args)
 						} else {
 							lazyStep(stage, task.run, target).each { step ->
 								step()

--- a/vars/lazyNode.groovy
+++ b/vars/lazyNode.groovy
@@ -1,0 +1,71 @@
+#!groovy
+
+/*
+ * This work is protected under copyright law in the Kingdom of
+ * The Netherlands. The rules of the Berne Convention for the
+ * Protection of Literary and Artistic Works apply.
+ * Digital Me B.V. is the copyright owner.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.transform.Field
+import org.jenkins.ci.lazy.Logger
+
+@Field private logger = new Logger(this)
+
+def call(stage, index, task, target, dist = null) {
+	logger.debug('Retrieving config')
+	def config = lazyConfig()
+
+	logger.debug("Detected tasks to be run on ${target}")
+	def label = target
+	if (config.labels[target]) {
+		label = config.labels[target]
+		logger.info("Mapping found for label ${target} = ${label}")
+	}
+
+	def name = "${stage}/${index}/${target}"
+	logger.info(name, "Preparing to branch on agent with label = ${label}")
+	def branch = [
+		(name): {
+			node(label: label) {
+				try {
+					checkout scm
+
+					ansiColor('xterm') {
+						// Execute pre closure first
+						if (task.pre) task.pre.call()
+
+						if (dist) {
+							lazyDocker(stage, task.run, dist, params.dockerArgs)
+						} else {
+							lazyStep(stage, task.run, target).each { step ->
+								step()
+							}
+						}
+
+						// Execute post closure at the end
+						if (task.post) task.post.call()
+					}
+				} catch (e) {
+					error e.toString()
+				} finally {
+					step([$class: 'WsCleanup'])
+				}
+			}
+		}
+	]
+
+	return branch
+}

--- a/vars/lazyStage.groovy
+++ b/vars/lazyStage.groovy
@@ -92,7 +92,9 @@ def call (body) {
 							node(label: label) {
 							    checkout scm
                                 try {
-									lazyDocker(params.name, task, dist, params.dockerArgs)
+									ansiColor('xterm') {
+										lazyDocker(params.name, task, dist, params.dockerArgs)
+									}
 								} catch (e) {
 									error e.toString()
 								} finally {
@@ -119,8 +121,10 @@ def call (body) {
 								checkout scm
 							try {
 								// Execute each steps
-								lazyStep(params.name, task.exec, target).each { step ->
-									step ()
+								ansiColor('xterm') {
+									lazyStep(params.name, task.exec, target).each { step ->
+										step ()
+									}
 								}
 							} catch (e) {
 								error e.toString()


### PR DESCRIPTION
Mainly:
- Support selection of node without label mapping
- Change default sdir to lazyDir
- Change exec to run in task map for lazyStage

Also:
- Improve regex to allow map parsing with commas and spaces
- Support ansiColor from lazyStage rather than only for lazyDocker
- Support Docker arguments from task level
- Implement lazyNode with pre/post for any task
- Simplify call to lazyNode with default task values
- Add more logging in lazyDocker, lazyStep and lazyNode